### PR TITLE
Fix edge cases regarding consideration of IProperty.IsImportant

### DIFF
--- a/src/ExCSS.Tests/Sheet.cs
+++ b/src/ExCSS.Tests/Sheet.cs
@@ -555,6 +555,25 @@ h1 { color: blue }");
         }
 
         [Fact]
+        public void CssMarginAllImportant()
+        {
+            var names = new[] { "margin-top", "margin-right", "margin-bottom", "margin-left" };
+            var decls = ParseDeclarations("margin: 20px !important;");
+            Assert.NotNull(decls);
+            Assert.Equal(4, decls.Length);
+
+            for (int i = 0; i < decls.Length; i++)
+            {
+                var propertyName = decls[i];
+                var decl = decls.GetProperty(propertyName);
+                Assert.Equal(names[i], decl.Name);
+                Assert.Equal(propertyName, decl.Name);
+                Assert.True(decl.IsImportant);
+                Assert.Equal("20px", decl.Value);
+            }
+        }
+
+        [Fact]
         public void CssSeveralFontFamily()
         {
             var prop = ParseDeclaration("font-family: \"Helvetica Neue\", Helvetica, Arial, sans-serif");

--- a/src/ExCSS.Tests/Sheet.cs
+++ b/src/ExCSS.Tests/Sheet.cs
@@ -574,6 +574,100 @@ h1 { color: blue }");
         }
 
         [Fact]
+        public void CssMarginImportantShorhandFollowedByNotImportantLonghand()
+        {
+            var names = new[] { "margin-top", "margin-right", "margin-bottom", "margin-left" };
+            var decls = ParseDeclarations("margin: 5px !important; margin-left: 3px;");
+            Assert.NotNull(decls);
+            Assert.Equal(4, decls.Length);
+
+            for (int i = 0; i < decls.Length; i++)
+            {
+                var propertyName = decls[i];
+                var decl = decls.GetProperty(propertyName);
+                Assert.Equal(names[i], decl.Name);
+                Assert.Equal(propertyName, decl.Name);
+                Assert.True(decl.IsImportant);
+                Assert.Equal("5px", decl.Value);
+            }
+        }
+
+        [Fact]
+        public void CssMarginImportantLonghandFollowedByNotImportantShorthand()
+        {
+            var names = new[] { "margin-left", "margin-top", "margin-right", "margin-bottom" };
+            var decls = ParseDeclarations("margin-left: 5px !important; margin: 3px;");
+            Assert.NotNull(decls);
+            Assert.Equal(4, decls.Length);
+
+            for (int i = 0; i < decls.Length; i++)
+            {
+                var propertyName = decls[i];
+                var decl = decls.GetProperty(propertyName);
+                Assert.Equal(names[i], decl.Name);
+                Assert.Equal(propertyName, decl.Name);
+
+                if (i == 0)
+                {
+                    Assert.True(decl.IsImportant);
+                    Assert.Equal("5px", decl.Value);
+                }
+                else
+                {
+                    Assert.False(decl.IsImportant);
+                    Assert.Equal("3px", decl.Value);
+                }
+            }
+        }
+
+        [Fact]
+        public void CssMarginNotImportantShorhandFollowedByImportantLonghand()
+        {
+            var names = new[] { "margin-top", "margin-right", "margin-bottom", "margin-left" };
+            var decls = ParseDeclarations("margin: 5px; margin-left: 3px !important;");
+            Assert.NotNull(decls);
+            Assert.Equal(4, decls.Length);
+
+            for (int i = 0; i < decls.Length; i++)
+            {
+                var propertyName = decls[i];
+                var decl = decls.GetProperty(propertyName);
+                Assert.Equal(names[i], decl.Name);
+                Assert.Equal(propertyName, decl.Name);
+
+                if (i < 3)
+                {
+                    Assert.False(decl.IsImportant);
+                    Assert.Equal("5px", decl.Value);
+                }
+                else
+                {
+                    Assert.True(decl.IsImportant);
+                    Assert.Equal("3px", decl.Value);
+                }
+            }
+        }
+
+        [Fact]
+        public void CssMarginNotImportantLonghandFollowedByImportantShorthand()
+        {
+            var names = new[] { "margin-top", "margin-right", "margin-bottom", "margin-left" };
+            var decls = ParseDeclarations("margin-left: 5px; margin: 3px !important;");
+            Assert.NotNull(decls);
+            Assert.Equal(4, decls.Length);
+
+            for (int i = 0; i < decls.Length; i++)
+            {
+                var propertyName = decls[i];
+                var decl = decls.GetProperty(propertyName);
+                Assert.Equal(names[i], decl.Name);
+                Assert.Equal(propertyName, decl.Name);
+                Assert.True(decl.IsImportant);
+                Assert.Equal("3px", decl.Value);
+            }
+        }
+
+        [Fact]
         public void CssSeveralFontFamily()
         {
             var prop = ParseDeclaration("font-family: \"Helvetica Neue\", Helvetica, Arial, sans-serif");

--- a/src/ExCSS/StyleProperties/Property.cs
+++ b/src/ExCSS/StyleProperties/Property.cs
@@ -46,7 +46,7 @@ namespace ExCSS
 
         internal bool CanBeUnitless => (_flags & PropertyFlags.Unitless) == PropertyFlags.Unitless;
 
-        internal bool CanBeInherited => (_flags & PropertyFlags.Inherited) == PropertyFlags.Inherited;
+        public bool CanBeInherited => (_flags & PropertyFlags.Inherited) == PropertyFlags.Inherited;
 
         internal bool IsShorthand => (_flags & PropertyFlags.Shorthand) == PropertyFlags.Shorthand;
 

--- a/src/ExCSS/StyleProperties/ShorthandProperty.cs
+++ b/src/ExCSS/StyleProperties/ShorthandProperty.cs
@@ -18,7 +18,11 @@ namespace ExCSS
             foreach (var property in properties)
             {
                 var value = DeclaredValue.ExtractFor(property.Name);
-                property.TrySetValue(value);
+
+                if (property.TrySetValue(value))
+                {
+                    property.IsImportant = this.IsImportant;
+                }
             }
         }
     }


### PR DESCRIPTION
Fix edge cases regarding consideration of IProperty.IsImportant

1) Reflect the value of IProperty.IsImportant correctly on longhand properties when generated from a shorthand property
For example: margin: 20px !important;
This should resolve all 4 shorthand properties with IsImportant=True. Before this fix this "inherited" aspect did not get reflected from the original property into the shorthand properties.

2) StylesheetComposer.FillDeclarations - Take into consideration priority when the same property or a mixture of related shorthand vs longhad versions of the same property are defined in the same stylesheet. 
Example 1: "margin-left: 5px !important; text-align:center; margin: 3px;";
Example 2: "margin: 5px !important; text-align:center; margin-left: 3px;";
Example 3: "background-color:green !important; text-align:center; background-color:yellow;";
In the above examples the value(s) that should remain as final for the repeated properties should be the ones denoted by the !important tag even though they are declared first.

Also expose Property.CanBeInherited