### PR TITLE
Added support for .NET >= 4.5.2 in ExCSS project

### DIFF
--- a/src/ExCSS.Tests/ExCSS.Tests.csproj
+++ b/src/ExCSS.Tests/ExCSS.Tests.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netcoreapp2.0</TargetFramework>
+    <TargetFrameworks>netcoreapp2.0;net452</TargetFrameworks>
     <AssemblyName>ExCSS.Tests</AssemblyName>
     <PackageId>ExCSS.Tests</PackageId>
     <GenerateRuntimeConfigurationFiles>true</GenerateRuntimeConfigurationFiles>

--- a/src/ExCSS.Tests/FontProperty.cs
+++ b/src/ExCSS.Tests/FontProperty.cs
@@ -1,7 +1,6 @@
 ﻿namespace ExCSS.Tests
 {
     using ExCSS;
-    using ExCSS;
     using Xunit;
 
     //[TestFixture]

--- a/src/ExCSS.Tests/MediaFeatures.cs
+++ b/src/ExCSS.Tests/MediaFeatures.cs
@@ -1,7 +1,6 @@
 ﻿namespace ExCSS.Tests
 {
     using ExCSS;
-    using ExCSS;
     using Xunit;
 
     //[TestFixture]

--- a/src/ExCSS.Tests/MediaList.cs
+++ b/src/ExCSS.Tests/MediaList.cs
@@ -1,8 +1,6 @@
 ﻿namespace ExCSS.Tests
 {
     using ExCSS;
-    using ExCSS;
-    using ExCSS;
     using Xunit;
     using System;
 

--- a/src/ExCSS.Tests/Property.cs
+++ b/src/ExCSS.Tests/Property.cs
@@ -1,7 +1,6 @@
 ﻿namespace ExCSS.Tests
 {
     using ExCSS;
-    using ExCSS;
     using Xunit;
 
     //[TestFixture]

--- a/src/ExCSS/ExCSS.csproj
+++ b/src/ExCSS/ExCSS.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netstandard2.0</TargetFramework>
+    <TargetFrameworks>netstandard2.0;net452</TargetFrameworks>
     <AssemblyName>ExCSS</AssemblyName>
     <PackageId>ExCSS-Core</PackageId>
     <Title>ExCSS .NET Stylesheet Parser</Title>
@@ -19,6 +19,22 @@
 4.0.1 - StyleRules made easier to access.
 4.0.0 - Fork of ExCss, udpated to .NET Standard and numerous methods/properties made public to make it usable in the real world.</PackageReleaseNotes>
   </PropertyGroup>
+
+  <PropertyGroup Condition="'$(TargetFramework)'=='net452'">
+    <Title>ExCSS-Core for .Net Framework 4.5.2</Title>
+    <DefineConstants>$(DefineConstants);NETFULL;NET452</DefineConstants>
+    <DisableImplicitFrameworkReferences>true</DisableImplicitFrameworkReferences>
+  </PropertyGroup>
+
+  <PropertyGroup Condition="'$(TargetFramework)'=='netstandard2.0'">
+    <Title>ExCSS-Core for .Net Standard 2.0</Title>
+    <DefineConstants>$(DefineConstants);NETSTANDARD;NETSTANDARD20</DefineConstants>
+  </PropertyGroup>
+  
+  <ItemGroup Condition="'$(TargetFramework)'=='net452'">
+    <Reference Include="System" />
+    <Reference Include="System.Core" />
+  </ItemGroup>
 
   <ItemGroup>
     <Folder Include="Properties\" />


### PR DESCRIPTION
- see https://github.com/vvvv/SVG/issues/596
- also fixed a few warnings due to double usings
