### PR TITLE
Fix Exception from Encoding.GetEncoding

### DIFF
--- a/src/ExCSS/TextEncoding.cs
+++ b/src/ExCSS/TextEncoding.cs
@@ -1,11 +1,14 @@
 ﻿using System;
 using System.Collections.Generic;
+using System.Linq;
 using System.Text;
 
 namespace ExCSS
 {
     public static class TextEncoding
     {
+        public static HashSet<string> AvailableEncodings = new HashSet<string>(from encoding in Encoding.GetEncodings() 
+                                                                               select encoding.Name);
         public static readonly Encoding Utf8 = new UTF8Encoding(false);
         public static readonly Encoding Utf16Be = new UnicodeEncoding(true, false);
         public static readonly Encoding Utf16Le = new UnicodeEncoding(false, false);
@@ -54,15 +57,13 @@ namespace ExCSS
 
         private static Encoding GetEncoding(string name)
         {
-            try
+            if (AvailableEncodings.Contains(name))
             {
                 return Encoding.GetEncoding(name);
             }
-            catch
-            {
-                // Catch all since WP8 does throw a different exception than W*.
-                return Utf8;
-            }
+
+            // Catch all since WP8 does throw a different exception than W*.
+            return Utf8;
         }
 
         private static Dictionary<string, Encoding> CreateEncodings()


### PR DESCRIPTION
Store available encodings and make sure that the encoding is available before calling Encoding.GetEncoding(name)

Creates a HashSet that contains the names of all of the encodings, and uses that to test.

The exception gets really annoying for people trying to use the library.
