### PR TITLE
Fix build warnings.

### DIFF
--- a/ExCSS.sln
+++ b/ExCSS.sln
@@ -11,8 +11,6 @@ Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "ExCSS", "src\ExCSS\ExCSS.cs
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "ExCSS.Tests", "src\ExCSS.Tests\ExCSS.Tests.csproj", "{2F5163CB-B410-402A-85D8-448F8125C5FA}"
 EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "ExCSS.RealWorldTest", "ExCSS.RealWorldTest\ExCSS.RealWorldTest.csproj", "{8D91B545-8FC4-494E-B636-6CB4637C779F}"
-EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -27,10 +25,6 @@ Global
 		{2F5163CB-B410-402A-85D8-448F8125C5FA}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{2F5163CB-B410-402A-85D8-448F8125C5FA}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{2F5163CB-B410-402A-85D8-448F8125C5FA}.Release|Any CPU.Build.0 = Release|Any CPU
-		{8D91B545-8FC4-494E-B636-6CB4637C779F}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
-		{8D91B545-8FC4-494E-B636-6CB4637C779F}.Debug|Any CPU.Build.0 = Debug|Any CPU
-		{8D91B545-8FC4-494E-B636-6CB4637C779F}.Release|Any CPU.ActiveCfg = Release|Any CPU
-		{8D91B545-8FC4-494E-B636-6CB4637C779F}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE

--- a/src/ExCSS.Tests/FontProperty.cs
+++ b/src/ExCSS.Tests/FontProperty.cs
@@ -1,7 +1,6 @@
 ﻿namespace ExCSS.Tests
 {
     using ExCSS;
-    using ExCSS;
     using Xunit;
 
     //[TestFixture]

--- a/src/ExCSS.Tests/MediaFeatures.cs
+++ b/src/ExCSS.Tests/MediaFeatures.cs
@@ -1,7 +1,6 @@
 ﻿namespace ExCSS.Tests
 {
     using ExCSS;
-    using ExCSS;
     using Xunit;
 
     //[TestFixture]

--- a/src/ExCSS.Tests/MediaList.cs
+++ b/src/ExCSS.Tests/MediaList.cs
@@ -1,8 +1,6 @@
 ﻿namespace ExCSS.Tests
 {
     using ExCSS;
-    using ExCSS;
-    using ExCSS;
     using Xunit;
     using System;
 

--- a/src/ExCSS.Tests/Property.cs
+++ b/src/ExCSS.Tests/Property.cs
@@ -1,7 +1,6 @@
 ﻿namespace ExCSS.Tests
 {
     using ExCSS;
-    using ExCSS;
     using Xunit;
 
     //[TestFixture]

--- a/src/ExCSS/Model/Symbols.cs
+++ b/src/ExCSS/Model/Symbols.cs
@@ -28,16 +28,16 @@ namespace ExCSS
         public const char DoubleQuote = (char) 0x22;        // "
         public const char CurvedQuote = (char) 0x60;        // `
         public const char QuestionMark = (char) 0x3f;       // ?
-        public const char Tab = (char) 0x09;                //tab
+        public const char Tab = (char) 0x09;                // tab
         public const char LineFeed = (char) 0x0a;           // line feeed
-        public const char CarriageReturn = (char) 0x0d;     //return
+        public const char CarriageReturn = (char) 0x0d;     // return
         public const char FormFeed = (char) 0x0c;           // form feed
         public const char Space = (char) 0x20;              // space
         public const char Solidus = (char) 0x2f;            // solidus /
         public const char NoBreakSpace = (char) 0xa0;       // no breaking space
         public const char ReverseSolidus = (char) 0x5c;     // reverse solidus \
         public const char Colon = (char) 0x3a;              // :
-        public const char ExclamationMark = (char) 0x21;    //!
+        public const char ExclamationMark = (char) 0x21;    // !
         public const char Replacement = (char) 0xfffd;      // replacement
         public const char Underscore = (char) 0x5f;         // _
         public const char RoundBracketOpen = (char) 0x28;   // (
@@ -47,7 +47,7 @@ namespace ExCSS
         public const char CurlyBracketOpen = (char) 0x7b;   // {
         public const char CurlyBracketClose = (char) 0x7d;  // }
         public const char Percent = (char) 0x25;            // %
-        public const int MaximumCodepoint = 0x10FFFF;       //The maximum allowed codepoint (defined in Unicode).
+        public const int MaximumCodepoint = 0x10FFFF;       // The maximum allowed codepoint (defined in Unicode).
         public static Dictionary<char, char> Punycode = new Dictionary<char, char>
         {
             {'。', '.'},


### PR DESCRIPTION
- Remove `ExCSS.RealWorldTest` project in solution.
- Fix [CS0105](https://docs.microsoft.com/dotnet/csharp/misc/cs0105) warnings.

